### PR TITLE
Properly configure tracing subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +790,50 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -1186,10 +1248,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ reqwest = { version = "0.11.26", features = ["json"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 tracing = "0.1.28"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 tungstenite = { version = "0.21.0", features = ["handshake", "native-tls"]}
 uuid = { version = "1.7.0", features = ["v4", "serde"] }
 rand = "0.8.5"

--- a/src/healthcheck.rs
+++ b/src/healthcheck.rs
@@ -12,8 +12,8 @@ pub async fn start_http_server() -> tokio::io::Result<()> {
         let (mut socket, _) = listener.accept().await?;
         tokio::spawn(async move {
             match socket.peer_addr() {
-                Ok(peer_addr) => tracing::info!("Handling connection from {}", peer_addr),
-                Err(err) => tracing::info!("Handling connection from unknown peer {}", err),
+                Ok(peer_addr) => tracing::debug!("Handling connection from {}", peer_addr),
+                Err(err) => tracing::debug!("Handling connection from unknown peer {}", err),
             }
             let response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHealthcheck OK";
             let _ = socket.write_all(response.as_bytes()).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use crate::healthcheck::start_http_server;
 use crate::slack::start_websocket_client;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 mod healthcheck;
 mod roulette;
@@ -8,9 +10,9 @@ mod slack_message;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .with_ansi(true)
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_ansi(std::env::var("TERM").is_ok()))
+        .with(tracing_subscriber::EnvFilter::from_env("PIZZAPICKER_LOG"))
         .init();
     let app_handle = tokio::spawn(async move {
         start_websocket_client().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod slack_message;
 async fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_ansi(std::env::var("TERM").is_ok()))
-        .with(tracing_subscriber::EnvFilter::from_env("PIZZAPICKER_LOG"))
+        .with(tracing_subscriber::EnvFilter::from_default_env())
         .init();
     let app_handle = tokio::spawn(async move {
         start_websocket_client().await;

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -128,6 +128,8 @@ async fn handle_disconnect_message(
     message: incoming::SlackDisconnectIncomingMessage,
     client: &Client,
 ) -> Option<SlackWebSocket> {
+    tracing::info!("Received disconnect message: {:?}", message.reason.as_str());
+
     match message.reason.as_str() {
         "link_disabled" => {
             tracing::info!("Link disabled, stopping bot");


### PR DESCRIPTION
Uses the EnvFilter with tracing_subscriber, and will hopefully avoid printing ANSI escape codes in prod.

Already deployed with PIZZAPICKER_LOG=debug